### PR TITLE
How to: docz needs yarn to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Docz theme build for [docz site](http://docz.site)!
 
-## Install and usage
+## Installation and usage
 
 Just install the dependencies, then run docz devserver to make changes!
 
@@ -10,6 +10,8 @@ Just install the dependencies, then run docz devserver to make changes!
 yarn install
 yarn dev
 ```
+
+The website will be available at [http://localhost:3000](http://localhost:3000).
 
 After you make your changes, please send me a pull request!
 

--- a/src/docs/home/components/HowTo.tsx
+++ b/src/docs/home/components/HowTo.tsx
@@ -62,7 +62,7 @@ export const HowTo = withRouter(({ history }) => (
       </Text>
       <Pre className="language-markdown">{mdxExample}</Pre>
       <Text>That's it, your docs is ready to fly!</Text>
-      <Pre className="language-bash">$ docz dev</Pre>
+      <Pre className="language-bash">$ yarn docz dev</Pre>
       <Button
         scale="big"
         kind="secondary"


### PR DESCRIPTION
If docz is installed locally (as the first step in the How To assumes), you need to run it with either `npx` or `yarn` for the command to work. Added this to the frontpage. 

Also included the port for localhost in README, because it took me a minute to figure it out :)