### PR TITLE
fix(getting-started): change commands to put in package.json

### DIFF
--- a/docs/introduction/pages/getting-started/index.mdx
+++ b/docs/introduction/pages/getting-started/index.mdx
@@ -23,8 +23,8 @@ $ yarn add docz --dev
 {
   "name": "mycoolproject",
   "scripts": {
-    "dev": "docz dev",
-    "build": "docz build"
+    "docz:dev": "docz dev",
+    "docz:build": "docz build"
   },
   "devDependencies": {
     "docz": "latest"

--- a/docs/introduction/pages/getting-started/index.mdx
+++ b/docs/introduction/pages/getting-started/index.mdx
@@ -35,7 +35,7 @@ $ yarn add docz --dev
 Now you can spin up your dev server by just running:
 
 ```
-$ yarn dev
+$ yarn docz:dev
 ```
 
 ## Using


### PR DESCRIPTION
I was create a example for my post with docz and create-react-app, but when tried to put in package.json the ```"dev": "docz dev"``` and ```"build": "docz build"```, i saw that there are the same commands to execute the project create-react-app. 
I believe that this problem happens to other people, so this pull request is to avoid future problems.

Thanks

