### PR TITLE
Specify extension when use indexHtml config

### DIFF
--- a/docs/documentation/pages/project-configuration/index.mdx
+++ b/docs/documentation/pages/project-configuration/index.mdx
@@ -176,7 +176,7 @@ const Wrapper = ({ children }) => (
 - Type: `string`
 - Default: `undefined`
 
-HTML filepath relative from root to use as `index.html` template. This can be useful if you want to put some external scripts, css links, and other things in the index file.
+HTML filepath relative from root to use as `index.tpl.html` template. This can be useful if you want to put some external scripts, css links, and other things in the index file.
 
 By default we use this HTML file:
 


### PR DESCRIPTION
Brackets are not handled by the dev server when passing HTML filepath `filename.html`. It should be `filename.tpl.html`