### PR TITLE
fix: Update indexHtml docs to match 0.10 change

### DIFF
--- a/docs/documentation/pages/project-configuration/index.mdx
+++ b/docs/documentation/pages/project-configuration/index.mdx
@@ -182,16 +182,18 @@ By default we use this HTML file:
 
 ```html
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ lang }}">
   <head>
     <meta charset="UTF-8">
     <meta name="description" content="{{ description }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>{{ title }}</title>
+    {{ head }}
   </head>
   <body>
     <div id="root" />
+    {{ footer }}
   </body>
 </html>
 ```


### PR DESCRIPTION
0.10 introduced a breaking change that required some new variables to be added to the `index.html` specified by `indexHtml`. This documents that change.