### PR TITLE
Update description of src config on Project Configuration page

### DIFF
--- a/docs/documentation/pages/project-configuration/index.mdx
+++ b/docs/documentation/pages/project-configuration/index.mdx
@@ -21,11 +21,8 @@ To customize your project configuration just create `doczrc.js` following this r
 - Type: `string`
 - Default: `./`
 
-Define the source folder that docz will find and parse your mdx files. Every file out of this folder will not be found.
+The root directory of your project. This directory contains both the code you intend to document and the `.mdx` files Docz will find and parse. Files outside of this directory will not be bundled properly.
 
-> ### Tips and tricks
->
-> If you want to boost performance, you can limit by passing your source folder here!
 
 ### dest
 


### PR DESCRIPTION
In setting up my Docz project, I found the description of the `src` configuration option on the website confusing. In this PR, I've tried to update the text to better describe the option as I understand it now.

In addition, I have removed `Tips and Tricks` section below the `src` config option. My thinking is such:
1. The tip doesn't seem very applicable to most use cases.
2. The way it was described as "boosting performance" made me want to immediately add it to my project even through it was really not necessary.