### PR TITLE
Make button import consistent with writing mdx section

### DIFF
--- a/docs/introduction/pages/documenting-your-things/index.mdx
+++ b/docs/introduction/pages/documenting-your-things/index.mdx
@@ -23,7 +23,7 @@ name: Button
 ---
 
 import { Playground } from 'docz'
-import Button from './Button'
+import { Button } from './Button'
 
 # Button
 
@@ -55,7 +55,7 @@ name: Button
 ---
 
 import { Playground, PropsTable } from 'docz'
-import Button from './'
+import { Button } from './'
 
 # Button
 


### PR DESCRIPTION
Currently the Button is a named export [here](https://www.docz.site/introduction/writing-mdx) whereas it is a default export [here](https://www.docz.site/introduction/documenting-your-things)
This PR makes all of them named export.