### PR TITLE
Improve wording in Introduction

### DIFF
--- a/docs/introduction/index.mdx
+++ b/docs/introduction/index.mdx
@@ -6,18 +6,18 @@ sidebar: true
 
 # Introduction
 
-Libraries that make our life easier coming up every day. Styleguides and design system are growing so fast. Today, tools that allow us to be quick and effective in what we are doing are really necessary. We can't lose time with tasks that should be trivial for us. Thinking about that **docz** came out.
+Libraries that make our lives easier are coming out every day. Styleguides and design systems are growing in popularity. Today, tools that allow us to be quick and effective in what we are doing are really necessary. We can't afford to lose time with tasks that should be trivial. This is why **docz** was created.
 
-Documenting our things is one of the most important and heavy processes when you're creating something new. We waste a lot of time with unnecessary setups to build something that can represent and we want with our own style.
+Documenting our things is one of the most important yet time-consuming processes when creating something new. We waste a lot of time with unnecessary setup in order to build something that has all the necessary content but also matches our own style.
 
 ## Principles
 
-When you want to create a design system or even a simple documentation for your project, you have so many different ways to do that. Looking over these alternatives, we got the best parts of them to fill the missing pieces of each one and build a tool with these principles:
+Whether you want to create a design system or just simple project documentation, you have many options available. Looking over these alternatives, we borrowed the best ideas from each and came up with these principles:
 
 - **Zero config and easy to learn.** No unnecessary build steps with confusing setups.
 - **Blazing fast.** Built with performance in mind from the start.
 - **Easy to customize.** Create something that will be easy to use and customize.
-- **MDX Based.** Have the best standard to write documents.
+- **MDX based.** The best standard for writing documentation.
 - **Pluggable.** Plugins are the best choice when you need a custom and flexible solution.
 
-Now you know our core principles. Go ahead and let's [Get it Started](/introduction/getting-started)!
+Now you know the core principles of docz. Let's [get started](/introduction/getting-started)!

--- a/docs/introduction/pages/customizing/index.mdx
+++ b/docs/introduction/pages/customizing/index.mdx
@@ -7,15 +7,15 @@ parent: Introduction
 
 # Customizing
 
-One of the greatest pain you can have when you're working with tools that allow you to create documentation and develop your components, is that it's ~~impossible~~ very difficult to customize and impress your brand style. In most cases, you have just a few limited features to do that, or you need to create everything from scratch.
+One of the greatest pains you can have when you're working with tools that allow you to create documentation and develop your components, is that it's ~~impossible~~ very difficult to customize and inject your brand. In most cases, you have just a few limited features to do that, or you need to create everything from scratch.
 
-Docz was created with this pain in mind. In order to make customization simple and give liberty and velocity to you without the need to create your things from scratch, we allow you to modify everything that you want, from the bundler configuration to a sidebar menu color of your documentation.
+Docz was created with this pain in mind. In order to make customization simple and give you freedom and velocity without the need to create your things from scratch, we allow you to modify everything that you want, from the bundler configuration to a sidebar menu color.
 
 In this section, we'll explain about what you need to know to do that!
 
 ## Project configuration
 
-The first most important thing is your project configuration. How you now know, Docz is a zero-config tool. This is good, but our effort to be zero-config is just to get out of your face the willingness to start a project. To make this possible we have a very complete project configuration that can be modified with your own taste!
+The first most important thing is your project configuration. As you now know, Docz is a zero-config tool. This is good, but our efforts to be zero-config are mainly to get you started. To make this possible we have a complete project configuration that can be modified to your own tastes.
 
 Creating your own configuration is very easy: just add a `doczrc.js` file in the root of your project:
 
@@ -41,11 +41,11 @@ export default {
 }
 ```
 
-Don't be scared with these properties, we'll explain more about it later, but you can see all the details about the file configuration in the [Project Configuration](/documentation/project-configuration) section.
+Don't be scared with these properties, we'll explain them later, but you can see all the details about the file configuration in the [Project Configuration](/documentation/project-configuration) section.
 
 ## Document settings
 
-Document settings can be something simple, but powerful. It should be defined in the top of the `.mdx` file using yaml and can be used to change the layout or the theme. By default there are some basic properties that all documents can have:
+Document settings can be something simple, but powerful. They should be defined in the top of the `.mdx` file using yaml and can be used to change the layout or the theme. By default there are some basic properties that all documents can have:
 
 ```markdown
 ---
@@ -55,13 +55,13 @@ menu: Documents
 ---
 ```
 
-These properties are basic but good to help you improve your document navigation. As you can see, they are pretty much self-explanatory, but here is their definition:
+These properties are basic but good to help you improve your document navigation. They are pretty much self-explanatory, but here is their definition:
 
 - `name` Define the name of your component.
 - `route` Define the route of your component. By default, if you don't pass any route, we'll use some kinda slug that is a filepath of your file with a route format.
 - `menu` You can group your documents into a single menu by changing this prop.
 
-If we stopped here, perhaps you couldn't do many customizations with this properties. So, all documents can have whatever property you want to define, and your theme will load these properties.
+If we stopped here, perhaps you couldn't do many customizations with these properties. So, all documents can have arbitrary properties that you define and your theme will load them.
 
 As of v0.12.4 the ordering of menus and submenus is done in `doczrc.js`, please [see the changelog for details](https://github.com/pedronauck/docz/releases/tag/v0.12.4).
 
@@ -84,7 +84,7 @@ By running docz and having your first `.mdx` file, you should see something like
 
 ![](https://cdn-std.dprcdn.net/files/acc_649651/ZOUyUu)
 
-What you see above is our [docz-default-theme](https://github.com/pedronauck/docz/tree/master/packages/docz-theme-default). It's very minimalist, but it has what you need to start writing beautiful documentation.
+What you see above is our [docz-default-theme](https://github.com/pedronauck/docz/tree/master/packages/docz-theme-default). It's minimalist, but it has everything you need to start writing beautiful documentation.
 
 ### Creating themes
 
@@ -101,9 +101,9 @@ export default {
 
 ### Modifying the existing theme
 
-Creating a theme from scratch can be necessary depending on how big is your project and how much time you have to build your own theme. But this is not always what you need: sometimes you just need to modify some colors, fonts, spaces or whatever another thing that have in your mind.
+Creating a theme from scratch may be necessary depending on how big your project is and how much time you have. But this is not always the case: sometimes you just need to modify some colors, fonts, spacing, etc.
 
-Docz is awesome because that: it makes possible for you to create your own theme from scratch in a very simple way or just modify some properties of the chosen theme:
+Docz makes it possible for you to create your own theme from scratch in a very simple way or just override some properties of the chosen theme:
 
 ```js
 // doczrc.js
@@ -125,13 +125,13 @@ With just these few lines you can tweak your theme to match your styles:
 
 ![](https://cdn-std.dprcdn.net/files/acc_649651/LUoBjJ)
 
-The `themeConfig` property is what make this possible. It's just an object that every theme can define in its creation and use along the theme components. This is very flexible because you can create your own theme with some default configuration and give the user the capability to modify by their own taste.
+The `themeConfig` property is what makes this possible. It's just an object that every theme can define and use within the theme components. This is very flexible because you can create your own theme with some default configuration and give the user the capability to modify to their own taste.
 
 ## Plugins
 
-Plugins are very useful to speed up the development process. This concept is very used and disseminated nowadays in a lot of awesome tools because with it you can modify a bunch of processes and customize the project to your needs by just plugging some packages.
+Plugins are helpful to speed up the development process. This concept is widely used nowadays in a lot of awesome tools because with it you can modify a bunch of processes and customize the project to your needs by just plugging in some packages.
 
-Using a plugin in docz is easy. All you need to do is install the plugin that you want to use and call it on your project configuration:
+Using a plugin in docz is easy. All you need to do is install the plugin that you want to use and call it in your project configuration:
 
 ```js
 // docsrc.js
@@ -142,4 +142,4 @@ export default {
 }
 ```
 
-As you can see, a plugin is just a function passed inside an array. You can read more about how to create a plugin and the plugin's API in the [Creating Plugins](/documentation/creating-plugins) section, and see all the plugins created until now in the [Plugins](/plugins) menu.
+As you can see, a plugin is just a function passed inside an array. You can read more about how to create a plugin and the plugin API in the [Creating Plugins](/documentation/creating-plugins) section, and see all the available plugins in the [Plugins](/plugins) menu.

--- a/docs/introduction/pages/deploying-your-docs/index.mdx
+++ b/docs/introduction/pages/deploying-your-docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-name: Deploying your docs
+name: Deploying Your Docs
 route: /introduction/deploying-your-docs
 order: 2
 parent: Introduction
@@ -7,15 +7,15 @@ parent: Introduction
 
 # Building your site
 
-Now that you have a lot of knowledge about write your docs and you're a real badass, let's go to talk how you can build and deploy your documentation.
+Now that you know about writing your docs and you're a real badass, let's talk about how you can build and deploy your documentation.
 
-Like all the other things seen so far, build and deploy your documentation is very easy. The first thing that you need to do is run the build script created at your `package.json`:
+Like all the other things seen so far, building and deploying your documentation is easy. The first thing that you need to do is run the build script created in your `package.json`:
 
 ```bash
 $ yarn build
 ```
 
-If everything that you did is right, this command will generate all static files for you in `.docz/dist` folder and you see something like that on your terminal:
+If everything goes well, this command will generate all static files for you in the `.docz/dist` folder and you will see something like this in your terminal:
 
 ![](https://cdn-std.dprcdn.net/files/acc_649651/qIFhkT)
 
@@ -30,20 +30,20 @@ export default {
 
 ## Deploying
 
-With your static files in hand, you can deploy your documentation wherever you want, is a simple process like host a static site.
+With your static files in hand, you can deploy your documentation wherever you want just like hosting any static site.
 
-So, if you understand nothing about deploys, we recommend a lot that you use the service we're using to host this doc that you're reading, called [Netlify](http://netlify.com/). Netlify is a really fantastic and very easy tool that you can deploy your application in an automatic way by running the deploy on every push from a branch in seconds.
+If you understand nothing about deploys, we highly recommend that you use the service we're using to host this doc that you're reading, called [Netlify](http://netlify.com/). Netlify is a really fantastic and easy tool that allows you to deploy your application in an automatic way by running the deploy on every push from a branch in seconds.
 
 First, after login or create a new account on Netlify, just create a _New site from git_:
 
 ![](https://cdn-std.dprcdn.net/files/acc_649651/YTCDFn)
 
-Connect your Git service and pick some repository
+Connect your Git service and pick some repository:
 
 ![](https://cdn-std.dprcdn.net/files/acc_649651/cc2g4u)
 
-After that, just fill settings like bellow, passing your build command and the destination folder:
+After that, just fill settings like below, passing your build command and the destination folder:
 
 ![](https://cdn-std.dprcdn.net/files/acc_649651/3uvA9J)
 
-That's it, now you have your documentation hosted in a domain with a very nice and quick deploy process configured.
+That's all. Now you have your documentation hosted on a domain with a quick and easy deploy process configured.

--- a/docs/introduction/pages/documenting-your-things/index.mdx
+++ b/docs/introduction/pages/documenting-your-things/index.mdx
@@ -5,13 +5,13 @@ order: 1
 parent: Introduction
 ---
 
-# Documenting your Things
+# Documenting Your Things
 
 With all the capabilities of MDX in mind, we know that you can do a lot of things using this syntax and this is what we want to do, explore the full power of components and reliability of markdown to improve and facilitate your documentation flow.
 
 ## Built-in components
 
-Docz has some built-in components that help you to document your things. Using the power of components and making some AST parsing algorithms to work on the source data for these components, we can do a lot of things, like render your components on the fly, create tables with contents, custom getters by traversing your file, etc. The sky is the limit here!
+Docz has built-in components that help you to document your things. Using the power of components and AST parsing algorithms to work on the source data for these components, we can do a lot of things, like render your components on the fly, create tables with contents, custom getters by traversing your file, etc. The sky is the limit here!
 
 ### Component Playground
 
@@ -43,11 +43,9 @@ As you see, `<Playground>` rendered your component in a blank state, and right b
 
 ### Table of Properties
 
-Maybe the most important thing when you write a component is to know which properties it has. This is useful so you know what it can do and how you can modify its behavior or style. But, keeping a good properties documentation of your component can be boring, because you need to write the props specification and maintain the original props definition. And we know that to keep these two things in sync can be troublesome!
+Maybe the most important thing when you write a component is to know which properties it has. This is useful so you know what it can do and how you can modify its behavior or style. However, keeping a good properties documentation of your component can be boring, because you need to write the props specification and maintain the original props definition. And we know that to keep these two things in sync can be troublesome!
 
-Docz has a nice component to solve your problem: the `<PropsTable>` is a simple component that automatically gets the props definition of your component and transforms in a table with the values. Simple like that and works nicely with Flow and Typescript.
-
-To solve this issue, you can use docz `<PropsTable>`:
+Docz offers a solution to this problem: the `<PropsTable>` is a simple component that automatically gets the props definition of your component and displays a table with all the values. Simple like that and works nicely with Flow and Typescript.
 
 ```markdown
 ---
@@ -77,8 +75,8 @@ And now you have a table of properties:
 >
 > To make `<PropsTable>` work, you need to export your component as the `default` export. This is a very bad limitation of React Docgen, but is something necessary right now!
 
-You can see more about our built-ins components on [Components API](/documentation/components-api).
+You can see more about our built-in components on [Components API](/documentation/components-api).
 
 ## Just the beginning
 
-As we mentioned before, the sky is the limit here. With MDX you have a lot of power and can do a lot of things. We think that this is just the beginning: by combining AST parsing inside the construction of the components, it's possible to come with a lot of out the box ideas, and Docz is the better place to do that!
+As we mentioned before, the sky is the limit here. With MDX you have a lot of power and can do a lot of things. We think that this is just the beginning: by combining AST parsing inside the construction of the components, it's possible to come up with a lot of out the box ideas, and Docz is the ideal place to do that!

--- a/docs/introduction/pages/getting-started/index.mdx
+++ b/docs/introduction/pages/getting-started/index.mdx
@@ -16,7 +16,7 @@ $ yarn add docz --dev
 
 > ### Tips and tricks
 >
-> After you installed docz on your project, it can be a good choice to put two scripts on your `package.json` to run docz for you. This is an **optional step**, but very useful:
+> After you installed docz in your project, you may find it convenient to add two scripts in your `package.json` to run docz for you. This is an **optional step**:
 
 ```json
 {
@@ -31,7 +31,7 @@ $ yarn add docz --dev
 }
 ```
 
-Now you can spin up your dev server by just running:
+Now you can spin up your dev server just by running:
 
 ```
 $ yarn docz:dev
@@ -39,11 +39,11 @@ $ yarn docz:dev
 
 ## Using
 
-With your dev server up, you can start to write your documents.
+With your dev server up, you can start writing your documentation.
 
-Docz uses [MDX](https://github.com/mdx-js/specification) as a standard format because of the flexibility that turns possible to write JSX inside markdown files. Really cool, no?
+Docz uses [MDX](https://github.com/mdx-js/specification) as a standard format because of the flexibility of writing JSX inside markdown files. Really cool, no?
 
-One thing that is very important here is that you **don't need to follow any strict file architecture**, you can just create your `.mdx` files **anywhere on your project**.
+Note that you **don't need to follow any strict file architecture**. You can just create your `.mdx` files **anywhere in your project**.
 
 So, let's create our first `.mdx` and give it a name:
 
@@ -63,4 +63,4 @@ With the server up and your first `.mdx` created, you can open your browser and 
 
 Easy, right?
 
-Now that you know how to get started with docz, see the [next section](/introduction/writing-mdx) where we'll talk a little bit more about MDX and how you can use it to write your documents.
+Now that you know how to get started with docz, see the [next section](/introduction/writing-mdx) where we'll delve into MDX and how you can use it to write your documents.

--- a/docs/introduction/pages/writing-mdx/index.mdx
+++ b/docs/introduction/pages/writing-mdx/index.mdx
@@ -6,7 +6,7 @@ parent: Introduction
 
 # Writing MDX
 
-MDX is something really cool when it comes to writing documents and pages because it combines the readability of markdown with the expressivity and power of components. This is what makes MDX so powerful. According to the [specification](https://github.com/mdx-js/specification), it was developed because:
+MDX is well suited for writing documents and pages because it combines the readability of markdown with the expressivity and power of components. This is what makes MDX so powerful. According to the [specification](https://github.com/mdx-js/specification), it was developed because:
 
 > ### Why MDX?
 >
@@ -14,7 +14,7 @@ MDX is something really cool when it comes to writing documents and pages becaus
 
 ## Working with components
 
-If you want to know more about how MDX works, parse and transpile files, it has a [specification](https://github.com/mdx-js/specification) that's a good read. But now, we'll assume that you just need to know that with MDX you can use your components inside your markdown files, just that!
+If you want to know more about how MDX works, parsing and transpiling files, it has a [specification](https://github.com/mdx-js/specification) that's a good read. But for now, you only need to know that with MDX you can use your components inside your markdown files.
 
 But how? Let's take a look at how we can improve our `.mdx` created in the previous section by importing and using a component inside it:
 
@@ -38,13 +38,13 @@ And, if you really have a `Button` component to import, you'll see something lik
 
 > ### Note
 >
-> It's important to know that by some mvp reasons, until now docz only works with React components. But stay calm, we working to bring Preact, Vue and some others libraries to docz!
+> It's important to know that for some MVP reasons, until now docz only works with React components. But stay calm, we are working to bring Preact, Vue and some others libraries to docz!
 
 ## Using Remark and Rehype Plugins
 
 Since MDX uses the [remark](https://github.com/remarkjs/remark)/[rehype](https://github.com/rehypejs/rehype) ecosystems, you can use plugins to modify the AST on different stages of the process and make your documentation better.
 
-To use plugins you just need set `mdPlugins` for remark plugins and `hastPlugins` for rehype plugins on your project configuration:
+To use these plugins, set `mdPlugins` for remark plugins and `hastPlugins` for rehype plugins in your project configuration:
 
 ```js
 import images from 'remark-images'
@@ -57,7 +57,7 @@ export default {
 
 ## Using theme components
 
-If you want to pass default theme components to some component that you import on your mdx, you can do that by passing the prop on the fly:
+If you want to pass default theme components to some component that you import in your `.mdx`, you can do that by passing the prop on the fly:
 
 ```markdown
 ---
@@ -69,6 +69,6 @@ import { MyComponent } from './MyComponent'
 <MyComponent components={components} />
 ```
 
-Although MDX is very powerful, it's very simple too, so there's nothing more to know to work with MDX, it's just that. With this in mind, we open a whole new world of possibilities using markdown and components together and Docz can make possible to turn this experience better for you to write your docs.
+Although MDX is powerful, it's simple too, so there's nothing more to know to work with MDX. With this in mind, we open a whole new world of possibilities using markdown and components together and Docz leverages this to improve your experience while writing docs.
 
-So, now both we know how MDX works and what it can do, see how Docz can help you to [document your things](/introduction/documenting-your-things) by using our helper components!
+Now that we know how MDX works and what it can do, see how Docz can help you to [document your things](/introduction/documenting-your-things) by using our helper components!


### PR DESCRIPTION
Fixed some grammar and clarified things that were unclear.

Common themes:
- Case consistency ("Title Case" vs "Sentence case")
- Fix [comma splices](https://en.wikipedia.org/wiki/Comma_splice)
- Avoid the word [very](https://ruthlesseditor.com/the-very-wise-avoid-very/)