### PR TITLE
Fixed the how-to example

### DIFF
--- a/docs/home/components/HowTo.tsx
+++ b/docs/home/components/HowTo.tsx
@@ -72,7 +72,7 @@ export const HowTo = withRouter(({ history }) => (
     <Container>
       <Title>How to</Title>
       <Text>Install Docz as a dependency</Text>
-      <Pre className="language-bash">$ yarn add docz --dev</Pre>
+      <Pre className="language-bash">$ yarn add docz docz-theme-default --dev</Pre>
       <Text>
         Create an <code>.mdx</code> file anywhere in your project
       </Text>


### PR DESCRIPTION
Right now the instructions on the homepage are not sufficient to setup docz. Fixed it in this PR