### PR TITLE
fix: lowercase docz for valid homepage command

### DIFF
--- a/src/docs/home/components/HowTo.tsx
+++ b/src/docs/home/components/HowTo.tsx
@@ -91,7 +91,7 @@ export const HowTo = () => (
       </Text>
       <Pre className="language-markdown">{mdxExample}</Pre>
       <Text>That's it, your docs are ready to fly!</Text>
-      <Pre className="language-bash">$ yarn Docz dev</Pre>
+      <Pre className="language-bash">$ yarn docz dev</Pre>
       <Link to="/docs/getting-started">More info</Link>
     </Container>
   </Wrapper>


### PR DESCRIPTION
`yarn Docz dev` is not a valid command, so lowercasing `docz` fixes that and communicates this on the home page of docz.site. 💻 