### PR TITLE
feat(themes): fixing default theme's GitHub link

### DIFF
--- a/src/docs/documentation/general/customizing.mdx
+++ b/src/docs/documentation/general/customizing.mdx
@@ -50,7 +50,7 @@ Running Docz and creating your `.mdx`, you should have this:
 
 ![](https://cdn-std.dprcdn.net/files/acc_649651/kXg01b)
 
-What you see above is our [docz-default-theme](https://github.com/pedronauck/docz/tree/master/packages/docz-theme-default).
+What you see above is our [docz-default-theme](https://github.com/pedronauck/docz/tree/master/core/docz-theme-default).
 It's minimalist, but it has everything you need to start writing your documentation.
 
 ### Creating themes

--- a/src/docs/documentation/references/creating-themes.mdx
+++ b/src/docs/documentation/references/creating-themes.mdx
@@ -263,4 +263,4 @@ How I told you, without pain and a lot of work your you can have a custom and ve
 
 ## Examples
 
-If you wanna see an example of theme created, you can see the [source code](https://github.com/pedronauck/docz-website) of this website that was entire build using Docz or the [source code](https://github.com/pedronauck/docz/tree/master/packages/docz-theme-default) of `docz-theme-default`.
+If you wanna see an example of theme created, you can see the [source code](https://github.com/pedronauck/docz-website) of this website that was entire build using Docz or the [source code](https://github.com/pedronauck/docz/tree/master/core/docz-theme-default) of `docz-theme-default`.

--- a/src/docs/documentation/references/project-configuration.mdx
+++ b/src/docs/documentation/references/project-configuration.mdx
@@ -233,7 +233,7 @@ export default {
 
 This is the config that your theme will use to customize it. By default, each theme has your own `themeConfig` that you can modify, so this object may vary according to each theme.
 
-You can see the theme config of default theme [here](https://github.com/pedronauck/docz/blob/master/packages/docz-theme-default/src/config.ts)
+You can see the theme config of default theme [here](https://github.com/pedronauck/docz/blob/master/core/docz-theme-default/src/config.ts)
 
 ### wrapper
 

--- a/src/docs/themes/components/Cards.tsx
+++ b/src/docs/themes/components/Cards.tsx
@@ -24,7 +24,7 @@ export const Cards: SFC = () => (
       image="https://cdn-std.dprcdn.net/files/acc_649651/TkJQcV"
       name="docz-theme-default"
       description="Default theme created by docz"
-      link="https://github.com/pedronauck/docz/tree/master/packages/docz-theme-default"
+      link="https://github.com/pedronauck/docz/tree/master/core/docz-theme-default"
     />
   </Wrapper>
 )


### PR DESCRIPTION
The link to the GitHub repo for the default theme in several pages is wrong.  This corrects it.

Closes #54 