### PR TITLE
docs: fix broken Gatsby Themes link

### DIFF
--- a/src/docs/documentation/references/gatsby-theme.mdx
+++ b/src/docs/documentation/references/gatsby-theme.mdx
@@ -16,7 +16,7 @@ as a Gatsby Theme that's an NPM install away.
 The enjoy Gatsby theme features, use it as an environment for your documentation and give you more power yet, now we have
 a `gastby-theme-docz` that you can just use Docz as you use in the basic way, but enjoy all features of the Gatsby environment.
 
-If you liked it, but you don't know what is a Gatsby theme, please read [the official docs](https://www.gatsbyjs.org/docs/gatsby-theme)
+If you liked it, but you don't know what is a Gatsby theme, please read [the official docs](https://www.gatsbyjs.org/docs/themes/introduction/)
 
 ## How to use
 


### PR DESCRIPTION
The former Gatsby Themes URL was 404'ing. This PR updates to the new URL: https://www.gatsbyjs.org/docs/themes/introduction/