### PR TITLE
Add missing children param and use ComponentsProvider, not DocPreview

### DIFF
--- a/src/docs/documentation/references/creating-themes.mdx
+++ b/src/docs/documentation/references/creating-themes.mdx
@@ -120,13 +120,13 @@ const map = {
   inlineCode: components.Code,
 }
 
-const Theme = () => {
+const Theme = ({ children }) => {
   const config = useConfig()
   return (
     <ThemeProvider theme={config}>
-      <DocPreview components={map}>
+      <ComponentsProvider components={map}>
         {children}
-      </DocPreview>
+      </ComponentsProvider>
     </ThemeProvider>
   )
 }
@@ -200,14 +200,14 @@ const map = {
   inlineCode: components.Code,
 }
 
-const Theme = () => {
+const Theme = ({ children }) => {
   const config = useConfig()
   return (
     <ThemeProvider theme={config}>
       <Menu />
-      <DocPreview components={map}>
+      <ComponentsProvider components={map}>
         {children}
-      </DocPreview>
+      </ComponentsProvider>
     </ThemeProvider>
   )
 }


### PR DESCRIPTION
These two examples used a mix of the old and new API: importing ComponentsProvider, but rendering DocPreview. Also, `children` was undefined.