### PR TITLE
Clarify useMenus param in docs

### DIFF
--- a/src/docs/documentation/references/components-api.mdx
+++ b/src/docs/documentation/references/components-api.mdx
@@ -231,7 +231,7 @@ export function useDocs(): Docs[]
 ## `useMenus`
 
 This hook will return the menu built by Docz using your documents.
-Use this to get your menus easier of use `useDocs` if you want the documents ordered like the order in your project configuration.
+Use this to get your menus easier or use `useDocs` if you want the documents ordered like the order in your project configuration.
 
 ```js
 import { useMenus } from 'docz'
@@ -244,8 +244,8 @@ const App = () => {
 
 ### Params
 
-- **query**: `String`
-  Use this to filter menu results
+- **options**: `Object`
+  - `query: String` Use `query` to filter menu results. The query is matched against the menu headers, not page content.
 
 ### Return
 


### PR DESCRIPTION
It was not clear from the docs that the parameter of `useMenus` is an object, not a string.

Before (today):
![image](https://user-images.githubusercontent.com/4339443/57015449-302ed780-6c15-11e9-8805-90be73f89a85.png)

With this change:
![image](https://user-images.githubusercontent.com/4339443/57015460-3ae96c80-6c15-11e9-87d4-eb9e3209d07d.png)

I also tried to clarify that it does not search in page content, only in the menu headers.
Also fixed a typo: "of" -> "or"