### PR TITLE
Improve doc for theme path using file structure examples

### DIFF
--- a/src/docs/documentation/references/creating-themes.mdx
+++ b/src/docs/documentation/references/creating-themes.mdx
@@ -10,14 +10,27 @@ menu: References
 One of the main features of Docz is that you can create your own theme from scratch and just use data parsed from Docz.
 We provide a bunch of components that can help you to create your own theme without pain.
 
+Let's use this project structure through the following examples:
+
+```
+pages/
+  hello-world.mdx
+src/
+  ui/
+    Page.js
+  theme.js
+doczrc.js
+package.json
+```
+
 ## Setting theme filepath
 
-First of all, you need to set the path of your theme in the [Project Configuration](/docs/project-configuration) by changing the `theme` property:
+First of all, you need to set the path of your theme in the [Project Configuration](/docs/project-configuration) by changing the `theme` property.
 
 ```js
 // doczrc.js
 export default {
-  theme: 'src/my/theme/path',
+  theme: 'src/theme',
 }
 ```
 
@@ -26,6 +39,7 @@ export default {
 Then just create your component passing the `children` inside it and export it as default using the [`theme()`](/docs/components-api) high order component as an enhancer.
 
 ```js
+// src/theme.js
 import React from 'react'
 import { theme } from 'docz'
 
@@ -46,6 +60,7 @@ Each theme has your own default `themeConfig` object that define whatever you wa
 It's very useful to set something like custom fonts, colors, spaces, some styles properties and other project global variables.
 
 ```js
+// src/theme.js
 import React from 'react'
 import { theme } from 'docz'
 
@@ -66,6 +81,7 @@ By default, Docz will use this object as default configuration and merge it with
 Using together with `useConfig` hook you can do a lot of things, like use css-in-js theming or retrieve props from your `themeConfig` in a deep render component.
 
 ```js
+// src/theme.js
 import React from 'react'
 import { theme, useConfig } from 'docz'
 import { ThemeProvider } from 'emotion-theming'
@@ -97,11 +113,12 @@ provide for MDX and Docz each component that you want to render inside your docu
 components passed to the provider, you can easily change how your mdx file will be rendered and change default behaviors and styles.
 
 ```js
+// src/theme.js
 import React from 'react'
 import { theme, useConfig, ComponentsProvider } from 'docz'
 import { ThemeProvider } from 'emotion-theming'
 
-import * as components from './my-components'
+import * as components from './ui'
 
 const map = {
   page: components.Page,
@@ -155,11 +172,11 @@ The first one will give you information about all menus parsed from Docz and the
 First of all, create something like a `<Menu />` component (we using a menu just to illustrate here):
 
 ```js
-// Sidebar.js
+// src/Menu.js
 import React from 'react'
 import { useMenus, Link } from 'docz'
 
-const Menu = () => {
+export const Menu = () => {
   const menus = useMenus()
   return (
     <ul>
@@ -176,11 +193,12 @@ const Menu = () => {
 Now you have a fully functional navigation to your documentation and you can simply use it your `<Menu />` component inside your theme:
 
 ```js
+// src/theme.js
 import React from 'react'
 import { theme, useConfig, ComponentsProvider } from 'docz'
 import { ThemeProvider } from 'emotion-theming'
 
-import { Menu } from './menu'
+import { Menu } from './Menu'
 import * as components from './my-components'
 
 const map = {
@@ -245,6 +263,7 @@ This is just a page!
 After defining the hero page of your document, let's see how your `Page` component will look:
 
 ```js
+// src/ui/Page.js
 import React from 'react'
 
 import MyCoolHero from './MyCoolHero'

--- a/src/docs/documentation/references/project-configuration.mdx
+++ b/src/docs/documentation/references/project-configuration.mdx
@@ -218,8 +218,19 @@ Use this property to specify the theme for your site. You can pass the name of y
 ```js
 // doczrc.js
 export default {
-  theme: '/src/my/theme/folder',
+  theme: 'src/theme',
 }
+```
+
+Example project structure:
+
+```
+pages/
+  hello-world.mdx
+src/
+  theme.js
+doczrc.js
+package.json
 ```
 
 > ### Important


### PR DESCRIPTION
I have found the theme path config documentation to be a bit confusing, and it seems I am not the only one. https://github.com/pedronauck/docz/issues/856

I felt like an example project structure would really help in seeing how things are connected. So this PR adds an example file structure on the Project Configuration and Creating Themes pages.

![image](https://user-images.githubusercontent.com/4339443/57298412-716e2e00-70d2-11e9-8835-db460153e960.png)

![image](https://user-images.githubusercontent.com/4339443/57298434-7fbc4a00-70d2-11e9-893d-7d59c4aa8a2f.png)
