### PR TITLE
.md files are also included by default

### DIFF
--- a/src/docs/documentation/references/project-configuration.mdx
+++ b/src/docs/documentation/references/project-configuration.mdx
@@ -54,7 +54,7 @@ Define the source folder of **your components**. Only the files in this folder w
 ### files
 
 - Type: `string`
-- Default: `process.env.DOCZ_FILES || '**/*.mdx'`
+- Default: `process.env.DOCZ_FILES || '**/*.{md,markdown,mdx}'`
 
 Glob pattern used to find your files.
 By default, Docz finds all files inside the source folder that has a `.mdx` extension.


### PR DESCRIPTION
I noticed that a markdown file was being included in my docz build... The documentation does not match the [source code](https://github.com/pedronauck/docz/blob/c0749d32d9b806b8a83fb91f0dbb34203585df4f/core/docz-core/src/config/argv.ts#L119).

Looking at the other options, there are other discrepancies: I'm not sure whether these just need to be fixed in the documentation, or if there's some other code that produces the documented behavior: (comparing [argv.ts](https://github.com/pedronauck/docz/blob/c0749d32d9b806b8a83fb91f0dbb34203585df4f/core/docz-core/src/config/argv.ts) to [project-configuration.mdx](https://github.com/pedronauck/docz-website/blob/2189a1b559a2cdc44b3fa5cb79fa729154ddd3aa/src/docs/documentation/references/project-configuration.mdx))
```
default: getEnv('docz.ignore', []),
```
> Default: `['readme.md', 'changelog.md', 'code_of_conduct.md', 'contributing.md', 'license.md'],`

```
default: getEnv('docz.config', ''),
```
> Default: `'docz.json | .doczrc | doczrc.json |doczrc.js | docz.config.js | docz.config.json'`

