### PR TITLE
fix typos to gatsby theme documentation

### DIFF
--- a/src/docs/documentation/references/gatsby-theme.mdx
+++ b/src/docs/documentation/references/gatsby-theme.mdx
@@ -9,18 +9,17 @@ parent: Documetation
 
 > ⚠️ This is experimental and subject to breaking changes.
 
-Gatsby themes is one of the coolest features of all times in Gatsby, with the introduction of theming in Gatsby,
-it's easier than ever to get started building a Gatsby site. Shared functionality, data sourcing, and design can all be prepackaged
-as a Gatsby Theme that's an NPM install away.
+Gatsby themes is one of the coolest features of all time in Gatsby. With the introduction of theming in Gatsby,
+it's easier than ever to get started building a Gatsby site. Shared functionality, data sourcing, and design can all be prepackaged as a Gatsby Theme that's an NPM install away.
 
 The enjoy Gatsby theme features, use it as an environment for your documentation and give you more power yet, now we have
 a `gatsby-theme-docz` that you can just use Docz as you use in the basic way, but enjoy all features of the Gatsby environment.
 
-If you liked it, but you don't know what is a Gatsby theme, please read [the official docs](https://www.gatsbyjs.org/docs/themes/introduction/)
+If you like it, but you don't know what is a Gatsby theme, please read [the official docs](https://www.gatsbyjs.org/docs/themes/introduction/)
 
 ## How to use
 
-To use our gatsby theme it's so simple. First of all, just install some packages:
+It's so simple to use our Gatsby theme. First of all, just install some packages:
 
 ```
 yarn add gatsby gatsby-theme-docz docz docz-theme-default -D
@@ -75,7 +74,7 @@ module.exports = {
 }
 ```
 
-> We highly indicate that you set your configuration using `doczrc.js` because of live reload that will change in real time your project settings, if you set your configs using the theme defition you will need to reset your dev server in order to see your changes.
+> We highly recommend that you set your configuration using `doczrc.js` because of live reload that will change in real time your project settings, if you set your configs using the theme definition you will need to reset your dev server in order to see your changes.
 
 ## Getting data
 
@@ -83,7 +82,7 @@ Using our Gatsby Theme you can enjoy all our hooks to get data for your pages an
 So, you can create isolated pages on Gatsby using gatsby pages and get data from Docz or maybe pass data
 for your Docz documents using source from gatsby.
 
-Imagine, that you have your home page insides `/pages` and you want to show all documents parsed from Docz. You can easy get this by doing:
+Imagine, that you have your home page inside `/pages` and you want to show all documents parsed from Docz. You can easy get this by doing:
 
 ```js
 import React from 'react'
@@ -99,7 +98,7 @@ const Home = () => {
 export default Home
 ```
 
-Or you can have a mdx document inside Docz that have data from Gatsby too:
+Or you can have a mdx document inside Docz that has data from Gatsby too:
 
 ```markdown
 ---


### PR DESCRIPTION
Fixing a few typos and sentence structure to make the documentation clearer for a native English speaker.

Please get in touch if you have any questions.