### PR TITLE
Remove create-docz-app from documentation

### DIFF
--- a/src/docs/documentation/general/getting-started.mdx
+++ b/src/docs/documentation/general/getting-started.mdx
@@ -11,8 +11,6 @@ First off, try take a look and check out [docz's `examples` directory](https://g
 
 Start by adding **docz** as a dependency:
 
-> There's also a [create-docz-app](https://www.npmjs.com/package/create-docz-app), which you can be using to start new projects with docz even quicker, but it's totally independent from docz, therefore not officially supported. Once we strongly don't believe that it should be part of what we want to bring to the community as a project, but feel free to use it as much as you need, especially to replace `create-react-app`, for example, to create new projects.
-
 ```sh
 yarn add docz # react react-dom
 ```


### PR DESCRIPTION
EDIT : Fixed create-docz-app. No need for this CR anymore


`create-docz-app` has not been updated in a few years and errors out when you try to use it. This is very frustrating for newcomers. 

This removes its mention from the site